### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -1,4 +1,6 @@
 name: Update Major Version Tag
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/joshjohanning-org/reusable-workflows/security/code-scanning/1](https://github.com/joshjohanning-org/reusable-workflows/security/code-scanning/1)

To fix the problem, we must add an explicit `permissions` block to the workflow or to the specific job where it is needed. The minimal secure starting configuration is to add:

```yaml
permissions:
  contents: write
```

at the workflow or job level, since the update of version tags requires write access to repository contents. This can be applied at the top level (applies to all jobs) or within the `update-majorver` job. Since there is only one job, adding it above `jobs:` (top level) is the clearest. Insert the above lines after the `name:` at the top of the workflow file.

No imports or additional definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
